### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">🔵 Proton - UI Composition</h1>
 <h3 align="center">😱 ~5kb gzip, DOM-first, Rootless, Android-style, Component-based, No build</h3>
-<h4 align="center">Full TypeScript Support, Based on <a href="https://dev.to/framemuse/no-framework-principle-arised-2n39">No Framework Principle</a></h4>
+<h4 align="center">Full TypeScript Support, Based on the <a href="https://dev.to/framemuse/no-framework-principle-arised-2n39">No Framework Principle</a></h4>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@denshya/proton">
@@ -20,13 +20,13 @@ bun i @denshya/proton
 
 ## What is "Rootless"?
 
-It means you don't have to hijack an element in order to render the App, it cancles Root Component and Host element completely.
+It means you don't have to hijack an element to render the App; it cancels the Root Component and Host element completely.
 
-That is a novel wording, another good phrase is "Reversed Element Factory Ownership".
-These all stand for a component (or element) factory function producing/providing ownership to owned elements rather than being a side-effects function,
-which only modifies given element.
+That is a novel wording; another good phrase is "Reversed Element Factory Ownership."
+These all stand for a component (or element) factory function producing/providing ownership to owned elements rather than being a side-effect function,
+which only modifies a given element.
 
-From querying the element and modifying
+From querying the element and modifying it:
 ```js
 const element = document.getElementById("id")
 makeWidget(element)
@@ -37,9 +37,9 @@ function makeWidget(element) {
 }
 ```
 
-To creating desired element and sharing ownership
+To creating the desired element and sharing ownership:
 ```js
-function createWidget() { // returns element instead.
+function createWidget() { // returns an element instead.
   const element = document.createElement("div")
   element.style = "..."
   // ... Some other styling and structure
@@ -48,10 +48,10 @@ function createWidget() { // returns element instead.
 }
 ```
 
-This forces you to find the exact place where the new element should go, which may be tricky,
-this what Proton solves with JSX while still letting you choose the place to attach or reattach Proton Component.
+This forces you to find the exact place where the new element should go, which may be tricky.
+This is what Proton solves with JSX while still letting you choose the place to attach or reattach a Proton Component.
 
-Which allows you do to this: (Somewhat an alternative to Web Components)
+This allows you to do this: (Somewhat of an alternative to Web Components)
 
 ```jsx
 function Widget() {
@@ -82,9 +82,9 @@ _Continue reading about_ [JSX Reactivity](https://pinely-international.github.io
 
 ## Customization
 
-Adding your own JSX Attribute for any element is as easy as never.
+Adding your own JSX Attribute for any element is as easy as ever.
 
-For example, **`classMods`** - it will ensure BEM for elements without anoying imports.
+For example, **`classMods`** - it will ensure BEM for elements without annoying imports.
 ```jsx
 inflator.jsxAttributes.set("classMods", context => {
   if (context.value == null) return
@@ -96,7 +96,7 @@ More about [customization](https://pinely-international.github.io/proton/categor
 
 ## Fault Tolerance
 
-Unlike to React - Proton will not propogate thrown errors to parents - errors in Children will not break Parents while you still can catch them.
+Unlike React, Proton will not propagate thrown errors to parents - errors in Children will not break Parents, while you can still catch them.
 
 ```jsx
 function Child() { throw new Error("Test") }
@@ -105,53 +105,53 @@ function Parent(this: Proton.Component) { return <div>123<Child /></div> }
 document.body.append(inflate.inflate(<Parent />)) // Will render `123` without errors.
 ```
 
-Learn how you [catch errors](https://pinely-international.github.io/proton/learn/guides/error)
+Learn how you can [catch errors](https://pinely-international.github.io/proton/learn/guides/error)
 
 ## Open Internals
 
-To maintain open internals this library uses Classes instead of Functions as factories and uses `private` identifier in TypeScript,
-which gives you propert types while not stopping you from experimenting with internal variables and even allowing you to override them in convential way.
+To maintain open internals, this library uses Classes instead of Functions as factories and uses the `private` identifier in TypeScript,
+which gives you proper types while not stopping you from experimenting with internal variables and even allowing you to override them in a conventional way.
 
 ## Similar Libraries
 
-If you want manage your components in a somewhat complex way (like in React), you can continue reading this, but otherwise you may want to consider these alternatives:
+If you want to manage your components in a somewhat complex way (like in React), you can continue reading this, but otherwise, you may want to consider these alternatives:
 
 - <https://github.com/kitajs/html>
 - https://github.com/reactivehtml/rimmel
 
 ## Why Proton over React?
 
-It is very similar to React, it tries to simplify development as we know it in React. 
+It is very similar to React; it tries to simplify development as we know it in React.
 
 |Feature|Description|
 |-------|-----------|
 |Extended Customization|Custom Attributes, Children Adapters, Element Transformation, Class extension|
-|No built-in State Manager|Any State Manager that supports Signal-like interface **will just** work in Proton, while there is no enforncement of one|
+|No built-in State Manager|Any State Manager that supports a Signal-like interface **will just** work in Proton, while there is no enforcement of one|
 |Signals/Observables Support|Native support for [WICG Observables](https://github.com/WICG/observable) and Signal-like structures|
 |No root elements|Any component can be **inflated** and attached anywhere|
-|Components can be Async 😱 (Client side)|Await your values and delay/schedule the views with fallbacks and initial view.|
-|Top level allowed|You can do anything in any scope, Proton doesn't put any constraints where or from something is initialized - enjoy!|
-|Children don't crash Parents|Error in the subtree will not break rendering of parents.|
-|Return any value|Components can be returned with **any** value, no seriously, even DOM Nodes/Elements will work.|
+|Components can be Async 😱 (Client side)|Await your values and delay/schedule the views with fallbacks and an initial view.|
+|Top-level allowed|You can do anything in any scope; Proton doesn't put any constraints on where or from what something is initialized - enjoy!|
+|Children don't crash Parents|An error in the subtree will not break the rendering of parents.|
+|Return any value|Components can be returned with **any** value; no seriously, even DOM Nodes/Elements will work.|
 |Class-based|Enables **tree-shaking**, **extensibility**, and **open internals**|
 
 **React Inherited Features**
 
 |Feature|Description|
 |-------|-----------|
-|Tree Context|Excplicit context sharing between subtree components|
+|Tree Context|Explicit context sharing between subtree components|
 |Conditional Rendering|Proton implements Conditional Mounting|
 |Layouts Swapping|Conditionally changing the whole component layout|
-|JSX|Proton supports React JSX, but it also has a flavor|
-|`ref` attribute|Access DOM element when it's ready - supports refs merging as well|
+|JSX|Proton supports React JSX, but it also has its own flavor|
+|`ref` attribute|Access a DOM element when it's ready - supports refs merging as well|
 |Event delegation|Proton subscribes to parents rather than directly to elements too (for lists) ([WIP](https://github.com/pinely-international/proton/issues/53))|
-|SSR|Provides extendable `JSXSerializer` and examples with full DOM support in DOM-less envrionments like servers|
-|Portal|Portals are natural and very easy, you just use component scoped inflator|
-|Error catching|Proton exposes clear API to catch errors and other|
+|SSR|Provides an extendable `JSXSerializer` and examples with full DOM support in DOM-less environments like servers|
+|Portal|Portals are natural and very easy; you just use a component-scoped inflator|
+|Error catching|Proton exposes a clear API to catch errors and others|
 
 **Problems to solve:**
 
-Proton isn't perfect, it's being developed
+Proton isn't perfect; it's being developed.
 https://github.com/pinely-international/proton/milestones
 
 ## Getting Started
@@ -161,7 +161,7 @@ function App() {
   return <div>Hello World!</div>
 }
 
-const inflator = new WebInflator
+const inflator = new WebInflator()
 const AppView = inflator.inflate(<App />)
 
 document.getElementById("root").replaceChildren(AppView)
@@ -169,7 +169,7 @@ document.getElementById("root").replaceChildren(AppView)
 
 ## JSX
 
-Proton supports JSX, it maps directly to [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) elements and allows any value to be put into attributes or as children of **any elements**. And it has a flavor comparing to React JSX.
+Proton supports JSX. It maps directly to [Document](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) elements and allows any value to be put into attributes or as children of **any element**. And it has a different flavor compared to React JSX.
 
 ```xml
 <div className="product-card">
@@ -177,8 +177,8 @@ Proton supports JSX, it maps directly to [Document](https://developer.mozilla.or
   <p>Description</p>
   <img src="/static/product-card.jpg" />
 
-  // You can put your weird staff.
-  <aside id={new MyIdObject} />
+  // You can put your weird stuff here.
+  <aside id={new MyIdObject()} />
 </div>
 ```
 
@@ -186,13 +186,13 @@ Learn more about [Inflator](#inflator) to provide custom handlers.
 
 ## TypeScript
 
-Report if there are anything uncovered for TypeScript.
+Report if there is anything uncovered for TypeScript.
 
 ## FAQ
 
 <details>
-  <summary>Does React hooks work in Proton?</summary>
-  No, but it's very extesible so probably some enthusiasts might implement it. BTW, even though libraries from other "frameworks" won't work in Proton, libraries for Proton are supposed to work in other frameworks too.
+  <summary>Do React hooks work in Proton?</summary>
+  No, but it's very extensible, so some enthusiasts might implement it. BTW, even though libraries from other "frameworks" won't work in Proton, libraries for Proton are supposed to work in other frameworks too.
 </details>
 <!-- <details>
   <summary>question?</summary>

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ bun i @denshya/proton
 
 ## What is "Rootless"?
 
-It means you don't have to hijack an element to render the App; it cancels the Root Component and Host element completely.
+It means you don't have to hijack an element to render the App, it cancels the Root Component and Host element completely.
 
-That is a novel wording; another good phrase is "Reversed Element Factory Ownership."
+That is a novel wording, another good phrase is "Reversed Element Factory Ownership."
 These all stand for a component (or element) factory function producing/providing ownership to owned elements rather than being a side-effect function,
 which only modifies a given element.
 
@@ -121,7 +121,7 @@ If you want to manage your components in a somewhat complex way (like in React),
 
 ## Why Proton over React?
 
-It is very similar to React; it tries to simplify development as we know it in React.
+It is very similar to React, it tries to simplify development as we know it in React.
 
 |Feature|Description|
 |-------|-----------|
@@ -130,9 +130,9 @@ It is very similar to React; it tries to simplify development as we know it in R
 |Signals/Observables Support|Native support for [WICG Observables](https://github.com/WICG/observable) and Signal-like structures|
 |No root elements|Any component can be **inflated** and attached anywhere|
 |Components can be Async 😱 (Client side)|Await your values and delay/schedule the views with fallbacks and an initial view.|
-|Top-level allowed|You can do anything in any scope; Proton doesn't put any constraints on where or from what something is initialized - enjoy!|
+|Top-level allowed|You can do anything in any scope, Proton doesn't put any constraints on where or from what something is initialized - enjoy!|
 |Children don't crash Parents|An error in the subtree will not break the rendering of parents.|
-|Return any value|Components can be returned with **any** value; no seriously, even DOM Nodes/Elements will work.|
+|Return any value|Components can be returned with **any** value, no seriously, even DOM Nodes/Elements will work.|
 |Class-based|Enables **tree-shaking**, **extensibility**, and **open internals**|
 
 **React Inherited Features**
@@ -146,12 +146,12 @@ It is very similar to React; it tries to simplify development as we know it in R
 |`ref` attribute|Access a DOM element when it's ready - supports refs merging as well|
 |Event delegation|Proton subscribes to parents rather than directly to elements too (for lists) ([WIP](https://github.com/pinely-international/proton/issues/53))|
 |SSR|Provides an extendable `JSXSerializer` and examples with full DOM support in DOM-less environments like servers|
-|Portal|Portals are natural and very easy; you just use a component-scoped inflator|
+|Portal|Portals are natural and very easy, you just use a component-scoped inflator|
 |Error catching|Proton exposes a clear API to catch errors and others|
 
 **Problems to solve:**
 
-Proton isn't perfect; it's being developed.
+Proton isn't perfect, it's being developed.
 https://github.com/pinely-international/proton/milestones
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ function App() {
   return <div>Hello World!</div>
 }
 
-const inflator = new WebInflator()
+const inflator = new WebInflator
 const AppView = inflator.inflate(<App />)
 
 document.getElementById("root").replaceChildren(AppView)


### PR DESCRIPTION
This PR simply fixes some typos (spelling mistakes, etc.) in the README I had noticed while going over the document.

Please accept this as a submission for Hacktoberfest and add the relevant tags.

Thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Improved grammar, phrasing, and typos across the README for clarity and consistency.
  * Reworded explanations (including FAQs and conceptual sections) for precision and readability.
  * Updated examples and inline comments for correct, natural wording.
  * Standardized punctuation, capitalization, and table entries.
  * No changes to functionality or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->